### PR TITLE
Default to false when `include_*` keys are missing

### DIFF
--- a/changelog.d/20240804_113757_kurtmckee_include_bug_issue_21.rst
+++ b/changelog.d/20240804_113757_kurtmckee_include_bug_issue_21.rst
@@ -1,0 +1,7 @@
+Changed
+-------
+
+-   Exclude FRU sections when the associated ``include_*`` key
+    has been removed from the ``[common]`` section. (#21)
+
+    The previous behavior was to always assume a section should be included.

--- a/src/fru/toml_format.py
+++ b/src/fru/toml_format.py
@@ -141,10 +141,10 @@ def load(
 
     dates = (("board", "mfg_date_time"),)
 
-    # Remove sections that are explicitly excluded.
+    # Remove sections that are excluded, either explicitly or implicitly.
     for section in ["internal", "chassis", "board", "product", "multirecord"]:
         include_section = f"include_{section}"
-        if not data["common"].get(include_section, True) and section in data:
+        if not data["common"].get(include_section, False) and section in data:
             del data[section]
         if include_section in data["common"]:
             del data["common"][include_section]

--- a/tests/include_defaults_to_false.toml
+++ b/tests/include_defaults_to_false.toml
@@ -1,0 +1,18 @@
+# Missing 'include_*' directives should default to false.
+
+[common]
+format_version = 1
+size = 256
+include_board = true
+
+[board]
+format_version = 1
+language_code = 0
+
+mfg_date_time = "2024-01-01 01:01"
+manufacturer = "Test Factory .Inc"
+product_name = "Test Board"
+serial_number = "01234"
+part_number = "5678"
+fru_file_id = "1"
+custom_fields = ["", ""]

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -194,3 +194,14 @@ def test_encoding():
 
     with unittest.mock.patch("builtins.open", replacement_open):
         assert fru.toml_format.load(path=path) is not None
+
+
+def test_include_values_default_to_false():
+    """Verify 'include_*' values default to false."""
+
+    path = os.path.join(os.path.dirname(__file__), "include_defaults_to_false.toml")
+    data = fru.toml_format.load(path)
+    assert "board" in data
+    assert "chassis" not in data
+    assert "product" not in data
+    assert "internal" not in data


### PR DESCRIPTION
Changed
-------

-   Exclude FRU sections when the associated ``include_*`` key
    has been removed from the ``[common]`` section. (#21)

    The previous behavior was to always assume a section should be included.


Closes #21