### PR TITLE
Speed up tox runs, particularly on Windows

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,8 @@ commands =
 
 
 [testenv:py{3.13, 3.12, 3.11, 3.10, 3.9, 3.8}]
+package = wheel
+wheel_build_env = build_wheel
 depends =
     coverage_erase
 deps =


### PR DESCRIPTION
Building a shared wheel, rather than the `.tar.gz`, is a significant performance improvement because otherwise pip will convert the `.tar.gz` file to a wheel for each test environment.