### PR TITLE
Suppress pip upgrade warnings in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -45,6 +45,9 @@ jobs:
 
       - name: "Setup Pythons"
         uses: "actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f" # v5.1.1
+        env:
+          # Disable pip upgrade warnings while setting up Python versions.
+          PIP_DISABLE_PIP_VERSION_CHECK: "1"
         with:
           python-version: "${{
             format(


### PR DESCRIPTION
These occur in the `setup-python` action and cannot be resolved until later.